### PR TITLE
fucking binlogs

### DIFF
--- a/things-to-check.yml
+++ b/things-to-check.yml
@@ -34,3 +34,4 @@
 - if the vpn timed out
 - if that's the wrong host
 - the security groups
+- fucking binlogs

--- a/things-to-check.yml
+++ b/things-to-check.yml
@@ -34,4 +34,4 @@
 - if the vpn timed out
 - if that's the wrong host
 - the security groups
-- fucking binlogs
+- the fucking binlogs


### PR DESCRIPTION
system.disk.in_use over device:/dev/xvdf1,host:shared-db was >= 0.85 on average during the last 10m.