### PR TITLE
Provide a git hook to automate tests.

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+# dup of the list in .travis.yml
+cargo build --locked
+cargo test
+cargo fmt -- --check
+cargo clippy -- --deny warnings
+cargo udeps --locked --all-targets

--- a/.git-hooks/pre-merge-commit
+++ b/.git-hooks/pre-merge-commit
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+# Run the pre-commit hook on merges, too.
+
+if [ -x .git-hooks/pre-commit ]; then
+    exec .git-hooks/pre-commit
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,9 @@ install:
     - cargo install cargo-udeps
     - cargo build
 
+# dup of the list in .git-hooks/pre-commit
 script:
-    - cargo build
+    - cargo build --locked
     - cargo test
     - cargo fmt -- --check
     - cargo clippy -- --deny warnings

--- a/README.md
+++ b/README.md
@@ -38,3 +38,44 @@ the page as a suggestion.
 
 Stable links provide the user with an index into this list. When you insert new
 items, insert them at the end.
+
+## Git hooks
+
+This project includes a pre-commit and a pre-merge-commit hook to run tests.
+Using this hook is optional, but it'll catch a lot of minor breakage before
+Travis does.
+
+**Security note**: Enabling in-repository hooks means that anyone who can commit
+code to this repository can run that code on your computer. Only do this if
+you're willing to take that chance.
+
+To set this up:
+
+* Install additional Rust components:
+
+    ```bash
+    rustup component add clippy rustfmt
+    ```
+
+* Install `cargo-udeps`:
+
+    ```bash
+    cargo install cargo-udeps
+    ```
+
+* Configure Git to use these hooks:
+
+    ```bash
+    git config core.hooksPath .git-hooks
+    ```
+
+This only needs to be done once, and applies only to this project. To undo this,
+unset `core.hooksPath`:
+
+```bash
+git config --unset core.hooksPath
+```
+
+You can also temporarily suppress the hook with `git commit --no-verify`, if you
+have broken code you want to check in, or if the internet is unavailable for
+Cargo to download dependencies.


### PR DESCRIPTION
When enabled, these hooks run the same tests as Travis, every commit.
There's nothing inherently wrong with a failing test run (it's a useful
signal), but the turnaround time for responding to Travis is a lot
longer than the turnaround time for responding to a local test failure.

The tradeoff here is that `git commit`, which is a _very_ common
operation, takes considerably longer when the hooks are enabled, and
runs a higher risk of giving users doorway effect issues.