### PR TITLE
Disregard test strings that can be converted to numbers when testing …

### DIFF
--- a/src/twelve.rs
+++ b/src/twelve.rs
@@ -195,6 +195,9 @@ mod tests {
         if env_port.contains("\x00") {
             return TestResult::discard();
         }
+        if env_port.parse::<u16>().is_ok() {
+            return TestResult::discard();
+        }
 
         env_locked(|| {
             env::set_var("PORT", env_port.to_string());


### PR DESCRIPTION
…non-numeric strings.

This is a straight oversight in the property. We asserted the proposition "the string contains no NULs implies the string will be rejected," but the test suite found a counterexample: `"0"` contains no NULs and is not rejected.

This is correct behaviour - the string "0" should be converted to the port number 0! So, now the proposition is more complex: "the string contains no NULs and cannot be converted to a number implies the string will be rejected." This closely mirrors the implementation, which isn't fantastic, but I can't see a more succinct and accurate way to frame the property.