### PR TITLE
Run CI through CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,19 @@
+version: 2.1
+
+jobs:
+    build:
+        docker:
+            - image: circleci/rust:1-buster
+        steps:
+            - checkout
+            - restore_cache:
+                key: cargo-{{ checksum "Cargo.lock" }}
+            - run: rustup component add clippy rustfmt
+            - run: cargo install cargo-udeps
+            - run: tools/checks
+            - save_cache:
+                key: cargo-{{ checksum "Cargo.lock" }}
+                paths:
+                    - ~/.cargo
+                    - ~/.rustup
+                    - target

--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -1,8 +1,3 @@
 #!/bin/bash -e
 
-# dup of the list in .travis.yml
-cargo build --locked
-cargo test
-cargo fmt -- --check
-cargo clippy -- --deny warnings
-cargo udeps --locked --all-targets
+exec tools/checks

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,5 @@ install:
     - cargo install cargo-udeps
     - cargo build
 
-# dup of the list in .git-hooks/pre-commit
 script:
-    - cargo build --locked
-    - cargo test
-    - cargo fmt -- --check
-    - cargo clippy -- --deny warnings
-    - cargo udeps --locked --all-targets
+    - tools/checks

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Things To Check
 
 [![Build Status](https://travis-ci.org/ojacobson/things-to-check.svg?branch=main)](https://travis-ci.org/ojacobson/things-to-check)
+[![CircleCI](https://circleci.com/gh/ojacobson/things-to-check.svg?style=svg)](https://circleci.com/gh/ojacobson/things-to-check)
 
 A friend of mine used to run an IRC bot that could provide "helpful"
 troubleshooting suggestions, based on places the folks in that chat had stubbed

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,26 @@
+# Local Tools
+
+The scripts in this directory assume they will be run from the root of the
+project, as `tools/NAME`. They contain brief, branch-free, composable scripts
+intended to be run to achieve frequent goals. They act as a shared shell
+history, of a sorts, and as a place to put command-line-ish code that needs to
+be shared by multiple components.
+
+Each script begins with a brief comment demonstrating the intended invocation
+and the effects.
+
+## Authoring
+
+Tools _should_ begin with a shebang or shell `set` expression that enables
+exiting on failure and that enables command echoing, followed by a documentation
+comment:
+
+```bash
+#!/bin/bash -ex
+
+# tools/my-example-tool
+#
+# Runs all example tasks.
+
+: …
+```

--- a/tools/check-dependencies
+++ b/tools/check-dependencies
@@ -1,0 +1,7 @@
+#!/bin/bash -ex
+
+# check-dependencies
+#
+# Checks that the dependencies in this project are all in use.
+
+cargo udeps --locked --all-targets

--- a/tools/check-lints
+++ b/tools/check-lints
@@ -1,0 +1,8 @@
+#!/bin/bash -ex
+
+# tools/check-lints
+#
+# Checks that the code in this project passes style checks.
+
+cargo fmt -- --check
+cargo clippy -- --deny warnings

--- a/tools/check-tests
+++ b/tools/check-tests
@@ -1,0 +1,8 @@
+#!/bin/bash -ex
+
+# tools/check-tests
+#
+# Checks that the code in this project passes incorrectness checks.
+
+cargo build --locked --all-targets
+cargo test

--- a/tools/checks
+++ b/tools/checks
@@ -1,0 +1,11 @@
+#!/bin/bash -ex
+
+# tools/checks
+#
+# Runs all code checks. If you're automating testing, call this rather than
+# invoking a test command directly; if you're adding a test command, add it here
+# or to one of the tools called from this script.
+
+tools/check-tests
+tools/check-lints
+tools/check-dependencies


### PR DESCRIPTION
This is an alternative to #9, using CircleCI.

Pro, relative to Github and Travis:

* Terse, general-case config.
* Fast as hell. Building cargo-udeps takes two minutes, not ten.
* Build output is nicely organized.

Con, same basis:

* Having to choose your own Docker image kind of sucks, as there's no real guidance on what to pick or why. I used Circle's Rust image, but that was a pure guess.
* I can't get caching to work. Less urgent here, but still notable.
* Aggressive visual design.
* Doesn't build merge commits for pull requests.