### PR TITLE
Revert to nightly.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: rust
-# 2020-06-17 - nightly hasn't had rustfmt since 2020-06-10, so builds fail on
-# that toolchain. We want to use it as far as is possible, though.
 rust:
-    - nightly-2020-06-10
+    - nightly
 
 cache: cargo
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2020-06-10
+nightly


### PR DESCRIPTION
As of the 20th, nightly once again has rustfmt, and Travis should build cleanly. I've made no real effort to find a long-term solution - I'm sure sooner or later nightly will lose critical binaries again, breaking the test suite, but I also don't want to pin to nightly-as-of-a-date as I will almost certainly forget to ever upgrade Rust.