### PR TITLE
Pin nightly again.

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2020-07-26


### PR DESCRIPTION
As predicted in 6b271b72d91ece90325b7d1691759d1c2b25707f, nightly-as-of-today is missing tools this project depends on (rustfmt, again).